### PR TITLE
Only use ctypes if on Windows

### DIFF
--- a/construct_editor/main.py
+++ b/construct_editor/main.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import dataclasses
+import sys
 import typing as t
 
 from pathlib import Path
@@ -339,10 +340,11 @@ icon = PyEmbeddedImage(
 
 def main():
     # Windows Icon fix: https://stackoverflow.com/a/1552105
-    import ctypes
+    if sys.platform == "win32":
+        import ctypes
 
-    myappid = "timrid.construct_hex_editor"
-    ctypes.windll.shell32.SetCurrentProcessExplicitAppUserModelID(myappid)
+        myappid = "timrid.construct_hex_editor"
+        ctypes.windll.shell32.SetCurrentProcessExplicitAppUserModelID(myappid)
 
     app = wx.App(False)
     frame = ConstructGalleryFrame(None)


### PR DESCRIPTION
I wanted to test this out but ran into an error when running this in Linux due to the use of ctypes, which is only available on Windows.

This pull request simply checks the os platform first before doing the Window's specific thing.