### PR TITLE
Hidden protected properties visible in list view

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# Intellij, pyCharm, etc.
+.idea/

--- a/README.md
+++ b/README.md
@@ -17,11 +17,18 @@ Features:
 - undo/redo in HexEditor and in ConstructEditor
 - extensible for custom adapters
 
-## Installation
+## Installation (for use in your own project)
 The preferred way to installation is via PyPI:
 ```
 pip install construct-editor
 ```
+
+## Installation as standalone
+The preferred way to installation is:
+- Open a command line in the project folder (`construct-editor`)
+- Create a new virtual environment via `virtualenv .venv`
+- Activate it with `.venv\Scripts\activate.ps1` or `.venv\Scripts\activate.bat`
+- Install via `pip install -e .` (remember the `.` at the end of the line)
 
 ## Getting started (Standalone)
 To start the standalone version, just execute the following in the command line:
@@ -50,15 +57,14 @@ frame.Show(True)
 app.MainLoop()
 ```
 
-This snipped generate a gui like this:
+This snipped generates a GUI like this:
 
 [Screenshot of the example]
 
 ## Widgets
 ### ConstructHexEditor
 This is the main widget ot this library. It offers a look at the raw binary data and also at the parsed structure.
-It offers a way to modify the raw binary data, which is then automaticly converted to the structed view. And also it support to modify the structed data and build the binary data from it.
-
+It offers a way to modify the raw binary data, which is then automaticly converted to the structed view. It also supports to modify the structed data and build the binary data from it.
 
 ### ConstructEditor
 This is just the right side of the `ConstructHexEditor`, but can be used also used as standalone widget. It provides:

--- a/construct_editor/gallery/test_greedyrange.py
+++ b/construct_editor/gallery/test_greedyrange.py
@@ -10,6 +10,7 @@ class Entry(cst.DataclassMixin):
     id: int = cst.csfield(cs.Int8sb)
     width: int = cst.csfield(cs.Int8sb)
     height: int = cst.csfield(cs.Int8sb)
+    _protected: int = cst.csfield(cs.Int8sb)
 
 
 constr = cs.GreedyRange(cst.DataclassStruct(Entry))
@@ -17,8 +18,8 @@ constr = cs.GreedyRange(cst.DataclassStruct(Entry))
 gallery_item = GalleryItem(
     construct=constr,
     example_binarys={
-        "5": bytes([1, 10, 10, 2, 10, 10, 3, 18, 18, 4, 10, 10, 5, 20, 20]),
-        "1": bytes([1, 10, 10]),
+        "5": bytes([1, 10, 10, 1, 2, 10, 10, 2, 3, 18, 18, 3, 4, 10, 10, 4, 5, 20, 20, 5]),
+        "1": bytes([1, 10, 10, 1]),
         "Zeros": bytes([]),
     },
 )

--- a/construct_editor/helper/wrapper.py
+++ b/construct_editor/helper/wrapper.py
@@ -616,14 +616,15 @@ class EntryConstruct(object):
                     subentry.dvc_item_restore_expansion()
 
     # default "add_nonstruct_subentries_to_list" ##############################
-    def create_flat_subentry_list(self, flat_subentry_list: List["EntryConstruct"]):
+    def create_flat_subentry_list(self, flat_subentry_list: List["EntryConstruct"], hide_protected: bool):
         """Create a flat list with all subentires, recursively"""
         subentries = self.subentries
         if subentries is not None:
             for subentry in subentries:
-                subentry.create_flat_subentry_list(flat_subentry_list)
+                subentry.create_flat_subentry_list(flat_subentry_list, hide_protected)
         else:
-            flat_subentry_list.append(self)
+            if not hide_protected or not self.name.startswith("_") and self.name != "":
+                flat_subentry_list.append(self)
 
     # default "create_obj_panel" ##############################################
     def create_obj_panel(self, parent) -> ObjEditorMixin:

--- a/construct_editor/widgets/construct_editor.py
+++ b/construct_editor/widgets/construct_editor.py
@@ -254,7 +254,7 @@ class ConstructEditorModel(dv.PyDataViewModel):
             raise ValueError(f"{repr(entry)} is no valid entry")
 
         flat_subentry_list: List["EntryConstruct"] = []
-        entry.create_flat_subentry_list(flat_subentry_list)
+        entry.create_flat_subentry_list(flat_subentry_list, self.hide_protected)
 
         return ".".join(flat_subentry_list[col].path)
 
@@ -353,7 +353,7 @@ class ConstructEditorModel(dv.PyDataViewModel):
         col = col - len(ConstructEditorColumn)
 
         flat_subentry_list: List["EntryConstruct"] = []
-        entry.create_flat_subentry_list(flat_subentry_list)
+        entry.create_flat_subentry_list(flat_subentry_list, self.hide_protected)
         if len(flat_subentry_list) > col:
             return flat_subentry_list[col].obj_str
         else:
@@ -663,7 +663,7 @@ class ConstructEditor(wx.Panel):
             if list_viewed_entry.subentries is not None:
                 for subentry in list_viewed_entry.subentries:
                     flat_list = []
-                    subentry.create_flat_subentry_list(flat_list)
+                    subentry.create_flat_subentry_list(flat_list, self.hide_protected)
                     list_cols = max(list_cols, len(flat_list))
 
         for list_col in range(list_cols):
@@ -678,7 +678,7 @@ class ConstructEditor(wx.Panel):
         if (entry.parent is not None) and (
             entry.parent in self._model.list_viewed_entries
         ):
-            entry.create_flat_subentry_list(flat_list)
+            entry.create_flat_subentry_list(flat_list, self.hide_protected)
 
         list_cols = self._dvc.GetColumnCount() - len(ConstructEditorColumn)
         for list_col in range(list_cols):


### PR DESCRIPTION
Fixed a bug that allowed protected properties (like: "_my_hidden_value") to be visible as columns in list view mode, even though "Hide Protected" was activated.