### PR TITLE
Fix a number of hex editor issues and add some keyboard management

### DIFF
--- a/construct_editor/widgets/hex_editor.py
+++ b/construct_editor/widgets/hex_editor.py
@@ -139,9 +139,9 @@ class HexEditorBinaryData:
         """get the value at the given index"""
         return self._binary[idx]
 
-    def get_range(self, idx: int, len: int):
+    def get_range(self, idx: int, length: int):
         """get the value at the given index"""
-        return bytes(self._binary[idx : idx + len])
+        return bytes(self._binary[idx : idx + length])
 
     def get_bytes(self) -> bytes:
         """return readonly version of the data"""
@@ -218,7 +218,10 @@ class HexEditorTable(Grid.GridTableBase):
         byte_idx = self.get_byte_idx(row, col)
         if value == "" and byte_idx >= len(self._binary_data):
             return
-        self._binary_data.overwrite_range(byte_idx, bytes([int(value, 16)]))
+        try:
+            self._binary_data.overwrite_range(byte_idx, bytes([int(value, 16)]))
+        except Exception:
+            return
 
     def GetValue(self, row: int, col: int):
         byte_idx = self.get_byte_idx(row, col)
@@ -391,10 +394,15 @@ class HexTextCtrl(wx.TextCtrl):
         logger.debug("key down before evt=%s" % evt.GetKeyCode())
         key = evt.GetKeyCode()
 
+        if key == wx.WXK_BACK or key == wx.WXK_DELETE:
+            self.SetValue(self.startValue)
+            self.Clear()
+
         if key == wx.WXK_TAB:
             wx.CallAfter(self.parentgrid._advance_cursor)
             return
-        if key == wx.WXK_ESCAPE:
+        if (key == wx.WXK_ESCAPE or key == wx.WXK_UP or key == wx.WXK_DOWN or
+                key == wx.WXK_LEFT or key == wx.WXK_RIGHT):
             self.SetValue(self.startValue)
             wx.CallAfter(self.parentgrid._abort_edit)
             return
@@ -775,7 +783,11 @@ class HexEditorGrid(Grid.Grid):
             else:
                 other_idx = sel[0]
 
+        if cursor_row + row_diff < 0:
+            return
         cursor_row += row_diff
+        if cursor_col + col_diff < 0:
+            return
         cursor_col += col_diff
         cursor_idx = self._table.get_byte_idx(cursor_row, cursor_col)
 
@@ -793,6 +805,8 @@ class HexEditorGrid(Grid.Grid):
             idx1, idx2 = idx2, idx1
         start_row, start_col = self._table.get_byte_rowcol(idx1)
         end_row, end_col = self._table.get_byte_rowcol(idx2)
+        if start_row < 0 or end_row < 0:
+            return
 
         first_col = 0
         last_col = self._table.GetNumberCols() - 1
@@ -847,14 +861,20 @@ class HexEditorGrid(Grid.Grid):
             return False
 
         if sel[1] == None:
-            len = 1
+            length = 1
         else:
-            len = sel[1] - sel[0] + 1
+            length = sel[1] - sel[0] + 1
 
-        byts = self._binary_data.remove_range(sel[0], len)
-
+        byts = self._binary_data.remove_range(sel[0], length)
+    
         self.ClearSelection()
         self._selection = (None, None)
+        idx = self._table.get_byte_idx(
+            self.GetGridCursorRow(), self.GetGridCursorCol())
+        if idx > len(self._editor.binary):
+            self.SetGridCursor(0, 0)
+        else:
+            self.SetGridCursor(self.GetGridCursorCoords())
 
         self.refresh()
         return True
@@ -872,11 +892,11 @@ class HexEditorGrid(Grid.Grid):
             return False
 
         if sel[1] == None:
-            len = 1
+            length = 1
         else:
-            len = sel[1] - sel[0] + 1
+            length = sel[1] - sel[0] + 1
 
-        byts = self._binary_data.get_range(sel[0], len)
+        byts = self._binary_data.get_range(sel[0], length)
 
         if wx.TheClipboard.Open():
             byts_str = byts.hex(" ")
@@ -907,7 +927,8 @@ class HexEditorGrid(Grid.Grid):
 
         if overwrite and insert:
             wx.MessageBox(
-                "Only one option is supported. 'overwrite' or 'insert'", "Warning"
+                "Only one option is supported. 'overwrite' or 'insert'",
+                "Warning"
             )
             return False
 
@@ -962,6 +983,20 @@ class HexEditorGrid(Grid.Grid):
                     )
                 self.SetGridCursor(row, col)
                 self.MakeCellVisible(row, col)
+
+        # Del
+        elif event.GetKeyCode() == wx.WXK_DELETE:
+            self._remove_selection()
+
+        # Insert
+        elif event.GetKeyCode() == wx.WXK_INSERT:
+            if self.read_only is True:
+                return False
+            sel = self._selection
+            if sel[0] is None:
+                return False
+            self._binary_data.insert_range(sel[0], b'\x00')
+            self._on_range_selecting_keyboard()
 
         # Shift+Up
         elif event.ShiftDown() and event.GetKeyCode() == wx.WXK_UP:
@@ -1078,7 +1113,7 @@ class HexEditorGrid(Grid.Grid):
 # #####################################################################################################################
 class HexEditor(wx.Panel):
     """
-    HexEdior Panel.
+    HexEditor Panel.
     """
 
     def __init__(


### PR DESCRIPTION
Fix a number of hex editor issues and add some keyboard management:

- fix crash when selecting or extending selection before the beginning of the hex editor using the shift LEFT and UP arrow keys
- Add Del key to remove a single byte and Ins key to add a single byte
- Appropriately position the cursor after group deletion
- Add basic BACK and DELETE key in hex cell editor
- Add basic arrow keys in hex cell editor doing the same as Escape
- Change "len" variable [which was the same as len()] to "length"
- Catch possible exception on int(value, 16)