### PR TITLE
allow construct version 2.10.67 or *higher*

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-construct==2.10.67
+construct>=2.10.67
 construct-typing==0.5.1
 pytest>=6.2.0
 numpy>=1.20.*


### PR DESCRIPTION
This PR changes the construct version requirement from fixed at 2.10.67, to be that version or any higher.

Fixes timrid/construct-editor#19