### PR TITLE
Add Destroy() after ShowModal() on on_uncaught_exception()

### DIFF
--- a/construct_editor/main.py
+++ b/construct_editor/main.py
@@ -82,6 +82,7 @@ class ConstructGalleryFrame(wx.Frame):
             None, "Uncaught Exception...", ExceptionInfo(etype, value, trace)
         )
         dial.ShowModal()
+        dial.Destroy()
 
 
 class ConstructGallery(wx.Panel):


### PR DESCRIPTION
Add `Destroy()` after `ShowModal()` on `on_uncaught_exception()`.

This is needed to allow safe application closure in case the `on_uncaught_exception()` modal form is shown.