### PR TITLE
Clear hex selection each time a construct panel entry is selected

### DIFF
--- a/construct_editor/wx_widgets/wx_construct_hex_editor.py
+++ b/construct_editor/wx_widgets/wx_construct_hex_editor.py
@@ -269,6 +269,7 @@ class WxConstructHexEditor(wx.Panel):
 
     def _show_stream_infos(self, stream_infos: t.List[StreamInfo]):
         hex_pnl = self.hex_panel
+        hex_pnl.hex_editor._grid.ClearSelection()
         panel_stream_mapping: t.List[t.Tuple[HexEditorPanel, StreamInfo]] = []
 
         # Create all Sub-Panels


### PR DESCRIPTION
I think it is useful to clear any coloring of performed selection in the hex panel each time an entry is selected in the construct right panel, so that the appropriate set of digits are highlighted in the hex panels, corresponding to the right selection. If this is not done, the highlighted hex digits remain not visible and can be confused with the previous hex selection.

Anyway, I'm not entirely sure that this patch is in the right mode.

Notice also that this patch does not actually cancel the hex selection itself, which can be copied for instance and the related message in the hex panel status line is not removed.