### PR TITLE
Autosize the app to 90% of the screen resolution geometry

### DIFF
--- a/construct_editor/main.py
+++ b/construct_editor/main.py
@@ -55,7 +55,8 @@ class ConstructGalleryFrame(wx.Frame):
         super().__init__(*args, **kwargs)
 
         self.SetTitle("Construct Gallery")
-        self.SetSize(1600, 1000)
+        width, height = wx.GetDisplaySize()
+        self.SetSize(int(width * 90 / 100), int(height * 90 / 100))
         self.SetIcon(icon.GetIcon())
         self.Center()
 


### PR DESCRIPTION
Autosize the app to 90% of the screen resolution geometry.

It might resolve https://github.com/timrid/construct-editor/issues/33